### PR TITLE
Fix inserting a previously deleted char with RGA.editText (wip)

### DIFF
--- a/ron-test/Main.hs
+++ b/ron-test/Main.hs
@@ -211,7 +211,7 @@ prop_event_roundtrip = property $ do
     event <- forAll Gen.event
     tripping event encodeEvent (Just . decodeEvent)
 
-prop_name_roundtip = property $ do
+prop_name_roundtrip = property $ do
     name <- forAll genName
     tripping name UUID.mkName $ \mu -> do
         u <- mu


### PR DESCRIPTION
Running `RGA.newFromText "x"`, `RGA.editText ""` and `RGA.editText "x"` results in an "empty" `RgaString`, instead of one representing "x".

The third edit is not generating any new ops, i.e. actually `prep rga2 === rga1expect`:

```
            350 ┃         rga2expect === prep rga2
                ┃         ^^^^^^^^^^^^^^^^^^^^^^^^
                ┃         │ Failed (- lhs =/= + rhs)
                ┃         │ - [ [ "*rga" , "#B/000000000p+000000003f" , "@`)s" , "!" ]
                ┃         │ - , [ "@)V" , ":`)q" , "'x'" ]
                ┃         │ - , [ "@)s" , ":0" , "'x'" ]
                ┃         │ - , [ "." ]
                ┃         │ - ]
                ┃         │ + [ [ "*rga" , "#B/000000000p+000000003f" , "@`)q" , "!" ]
                ┃         │ + , [ "@)V" , ":`)q" , "'x'" ]
                ┃         │ + , [ "." ]
                ┃         │ + ]
```

As I'm still very new to this: can you confirm that this is a bug or simply misinterpretation on my part? If it's a bug, can you confirm my expectation (`rga2expect`) is correct?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ff-notes/ron/39)
<!-- Reviewable:end -->
