### PR TITLE
Switch from `Either String a` to `MonadError String m => m a` in failable procedures

### DIFF
--- a/ron-rdt/lib/RON/Data/Time.hs
+++ b/ron-rdt/lib/RON/Data/Time.hs
@@ -23,4 +23,4 @@ instance ReplicatedAsPayload Day where
     fromPayload = \case
         [AInteger y, AInteger m, AInteger d] -> pure $
             fromGregorian (fromIntegral y) (fromIntegral m) (fromIntegral d)
-        _ -> Left "bad Day"
+        _ -> throwError "bad Day"

--- a/ron-storage/lib/RON/Storage/IO.hs
+++ b/ron-storage/lib/RON/Storage/IO.hs
@@ -42,6 +42,7 @@ import           System.Directory (canonicalizePath, createDirectoryIfMissing,
 import           System.IO.Error (isDoesNotExistError)
 
 import           RON.Epoch (EpochClock, getCurrentEpochTime, runEpochClock)
+import           RON.Error (throwErrorString)
 import           RON.Event (EpochTime, ReplicaClock, ReplicaId, advance,
                             applicationSpecific, getEvents, getPid)
 
@@ -109,7 +110,7 @@ instance MonadStorage Storage where
             when pathsDiffer $ do
                 newPathExists <- liftIO $ doesPathExist newPath
                 when newPathExists $
-                    throwError $ unwords
+                    throwErrorString $ unwords
                         [ "changeDocId"
                         , show old, "[", oldPath, "->", oldPathCanon, "]"
                         , show new, "[", newPath, "->", newPathCanon, "]"

--- a/ron-storage/ron-storage.cabal
+++ b/ron-storage/ron-storage.cabal
@@ -58,6 +58,7 @@ library
         filepath,
         mtl,
         network-info,
+        text,
         transformers,
         -- project
         ron,

--- a/ron-test/LwwStruct.hs
+++ b/ron-test/LwwStruct.hs
@@ -7,7 +7,7 @@ module LwwStruct (prop_lwwStruct) where
 import qualified Data.ByteString.Lazy.Char8 as BSLC
 import           Data.String.Interpolate.IsString (i)
 import           GHC.Stack (withFrozenCallStack)
-import           Hedgehog (MonadTest, Property, property, (===))
+import           Hedgehog (MonadTest, Property, evalEither, property, (===))
 import           Hedgehog.Internal.Property (failWith)
 
 import           RON.Data (getObject, newObject)
@@ -121,12 +121,12 @@ prop_lwwStruct = property $ do
     ex1 === ex2
 
     -- decode newly created object
-    example3 <- evalEitherS $ getObject ex2
+    example3 <- evalEither $ getObject ex2
     example0 === example3
 
     -- apply operations to the object (frame)
     ((str3Value, opt5Value, opt6Value), ex4) <-
-        evalEitherS $
+        evalEither $
         runNetworkSim $ runReplicaSim replica $ runExceptT $
         (`runStateT` ex2) $ do
             -- plain field
@@ -153,7 +153,7 @@ prop_lwwStruct = property $ do
     opt6Value === Just 74
 
     -- decode object after modification
-    example4 <- evalEitherS $ getObject ex4
+    example4 <- evalEither $ getObject ex4
     example4expect === example4
 
     -- serialize object after modification

--- a/ron-test/Main.hs
+++ b/ron-test/Main.hs
@@ -11,7 +11,8 @@ import qualified Data.ByteString.Lazy.Char8 as BSLC
 import           Data.Maybe (fromJust)
 import           GHC.Stack (withFrozenCallStack)
 import           Hedgehog (Gen, MonadTest, Property, PropertyT, annotate,
-                           annotateShow, forAll, property, tripping, (===))
+                           annotateShow, evalEither, forAll, property, tripping,
+                           (===))
 import qualified Hedgehog.Gen as Gen
 import           Hedgehog.Internal.Property (failWith)
 import qualified Hedgehog.Range as Range
@@ -262,7 +263,7 @@ prop_RGA_edit_idempotency = property $ do
     textX <- forAll Gen.shortText
     textY <- forAll Gen.shortText
     rgaY <-
-        evalEitherS $
+        evalEither $
         runNetworkSim $
         runReplicaSim (applicationSpecific 271) $
         runExceptT $ do
@@ -274,7 +275,7 @@ prop_RGA_edit_idempotency_back = property $ do
     textX <- forAll Gen.shortText
     textY <- forAll Gen.shortText
     rgaX' <-
-        evalEitherS $
+        evalEither $
         runNetworkSim $
         runReplicaSim (applicationSpecific 271) $
         runExceptT $ do
@@ -316,7 +317,7 @@ prop_RGA_delete_deleted = let
     in
     property $ do
         (rga0, rga1, rga2) <-
-            evalEitherS $
+            evalEither $
             runNetworkSim $
             runReplicaSim (applicationSpecific 234) $
             runExceptT $ do

--- a/ron-test/Words.hs
+++ b/ron-test/Words.hs
@@ -59,7 +59,7 @@ stems word
 
 rgaTrick1 :: Text -> Text -> (Object RgaString, Object RgaString)
 rgaTrick1 begin branch1 =
-    either error identity .
+    either (error . show) identity .
     runNetworkSim . runReplicaSim (applicationSpecific 1) . runExceptT $ do
         begin' <- RGA.newFromText begin
         branch1' <- (`execStateT` begin') $ RGA.editText branch1
@@ -67,11 +67,11 @@ rgaTrick1 begin branch1 =
 
 rgaTrick2 :: (Object RgaString, Object RgaString) -> Text -> Text
 rgaTrick2 (begin', branch1') branch2 =
-    either error identity .
+    either (error . show) identity .
     runNetworkSim . runReplicaSim (applicationSpecific 2) . runExceptT $ do
         branch2' <- (`execStateT` begin') $ RGA.editText branch2
-        end' <- liftEither $ reduceObject branch1' branch2'
-        liftEither $ RGA.getText end'
+        end' <- reduceObject branch1' branch2'
+        RGA.getText end'
 
 {-
 Found

--- a/ron/lib/RON/Error.hs
+++ b/ron/lib/RON/Error.hs
@@ -6,7 +6,6 @@ module RON.Error (
     errorContext,
     liftMaybe,
     throwErrorString,
-    -- throwErrorText,
 ) where
 
 import           Data.String (IsString, fromString)
@@ -18,9 +17,6 @@ errorContext ctx action = action `catchError` (throwError . ((ctx ++ ": ") ++))
 
 liftMaybe :: MonadE m => String -> Maybe a -> m a
 liftMaybe msg = maybe (throwErrorString msg) pure
-
--- throwErrorText :: MonadE m => Text -> m a
--- throwErrorText msg = throwError $ Error msg []
 
 throwErrorString :: (MonadError e m, IsString e) => String -> m a
 throwErrorString msg = throwError $ fromString msg

--- a/ron/lib/RON/Error.hs
+++ b/ron/lib/RON/Error.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+module RON.Error (
+    MonadE,
+    errorContext,
+    liftMaybe,
+    throwErrorString,
+    -- throwErrorText,
+) where
+
+import           Data.String (IsString, fromString)
+
+type MonadE = MonadError String
+
+errorContext :: MonadE m => String -> m a -> m a
+errorContext ctx action = action `catchError` (throwError . ((ctx ++ ": ") ++))
+
+liftMaybe :: MonadE m => String -> Maybe a -> m a
+liftMaybe msg = maybe (throwErrorString msg) pure
+
+-- throwErrorText :: MonadE m => Text -> m a
+-- throwErrorText msg = throwError $ Error msg []
+
+throwErrorString :: (MonadError e m, IsString e) => String -> m a
+throwErrorString msg = throwError $ fromString msg

--- a/ron/ron.cabal
+++ b/ron/ron.cabal
@@ -69,6 +69,7 @@ library
         RON.Binary.Serialize
         RON.Binary.Types
         RON.Epoch
+        RON.Error
         RON.Event
         RON.Event.Simulation
         RON.Text


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ff-notes/ron/48)
<!-- Reviewable:end -->
