### PR TITLE
Added Rga to ron types in schema

### DIFF
--- a/ron-schema/lib/RON/Schema/EDN.hs
+++ b/ron-schema/lib/RON/Schema/EDN.hs
@@ -47,6 +47,7 @@ prelude = Map.fromList
     , ("VersionVector", Type0 $ TObject TVersionVector)
     , ("Option",        Type1 $ TComposite . TOption)
     , ("ORSet",         Type1 $ TObject . TORSet)
+    , ("Rga",           Type1 $ TObject . TRga)
     ]
   where
     char = opaqueAtoms "Char" OpaqueAnnotations{oaHaskellType = Just "Char"}


### PR DESCRIPTION
Type Rga was missing in schema definition.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ff-notes/ron/63)
<!-- Reviewable:end -->
