### PR TITLE
Added unprefixed atom parsing. (#75)

### DIFF
--- a/ron-test/Common.hs
+++ b/ron-test/Common.hs
@@ -8,16 +8,21 @@ import           RON.Prelude
 
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Lazy.Char8 as BSLC
+import           Data.Either (partitionEithers)
+import           Data.Foldable (concat)
 import           Data.Generics (gcompare)
-import           Data.List.Extra (dropEnd)
+import           Data.List.Extra (dropEnd, head)
 import qualified Data.Map.Merge.Strict as Map
 import qualified Data.Map.Strict as Map
 import           Hedgehog (Property, property, (===))
 import           System.Directory (listDirectory)
+import           System.Directory.Tree (DirTree(File, file),
+                                        AnchoredDirTree((:/)), flattenDir,
+                                        readDirectoryWith)
 import           System.FilePath ((</>))
 import           Test.Tasty (TestTree, defaultMain, testGroup)
 import           Test.Tasty.Hedgehog (testProperty)
-import           Test.Tasty.HUnit (assertFailure, testCase)
+import           Test.Tasty.HUnit (assertEqual, assertFailure, testCase)
 
 import           RON.Data (reduceWireFrame)
 import qualified RON.Text as RT
@@ -34,8 +39,8 @@ main = do
 
 loadCases :: IO [TestTree]
 loadCases = do
-    files <- filter (".in.ron" `isSuffixOf`) <$> listDirectory commonTestDir
-    for files $ \fileIn -> do
+    inOutFiles <- filter (".in.ron" `isSuffixOf`) <$> listDirectory commonTestDir
+    testsInOut <- for inOutFiles $ \fileIn -> do
         let name = dropEnd 7 fileIn
             fileOut = name <> ".out.ron"
         chunksIn0  <- readChunks $ commonTestDir </> fileIn
@@ -51,16 +56,47 @@ loadCases = do
                         Map.assocs $ zipDef [] [] chunksIn1 chunksOut1
                     , not $ "06" `isPrefixOf` name
                     ]
+    noteFiles <- collectFiles "./data/note"
+    testsNote <-
+        for noteFiles $ \fileIn -> do
+            chunks0  <- readChunks fileIn
+            pure $ testGroup fileIn $
+                case chunks0 of
+                    Left err -> [testCase fileIn $ assertFailure err]
+                    Right c  -> let
+                        es = Map.elems c
+                        (lefts, rights) = partitionEithers $ fmap zipWithWireFrameRoundtrip es
+                        newTestCase ks = testCase ("comparing roundtrip for object " <> show ks)
+                        in
+                        fmap (testCase fileIn . assertFailure) lefts ++
+                        fmap (\(w, ks, w') -> newTestCase ks $ assertEqual "not equal" w w') rights
+    pure $ testsInOut ++ testsNote
   where
     commonTestDir = "../gritzko~ron-test"
     readChunks file = do
         bytes <- BSL.readFile file
         let eFrame = RT.parseWireFrame bytes
-        pure $ groupObjects . filter isRelevant <$> eFrame
+        pure $ filterWireFrame eFrame
+    filterWireFrame eFrame =
+        groupObjects . filter isRelevant <$> eFrame
+    wireFrameRoundtrip =
+        filterWireFrame . RT.parseWireFrame . RT.serializeWireFrame
+    zipWithWireFrameRoundtrip w = let
+        r = wireFrameRoundtrip w
+        f x = (w, head $ Map.keys x, concat . Map.elems $ x)
+        in f <$> r
     zipDef a b = Map.merge
         (Map.mapMissing $ const (,b))
         (Map.mapMissing $ const (a,))
         (Map.zipWithMatched $ const (,))
+
+collectFiles :: String -> IO [String]
+collectFiles d = do
+    (_ :/ dT) <- readDirectoryWith pure d
+    let isFile (File _ _) = True
+        isFile _ = False
+        fs = filter isFile (flattenDir dT)
+    pure $ map file fs
 
 groupObjects :: [WireChunk] -> Map UUID [WireChunk]
 groupObjects chunks =

--- a/ron-test/LwwStruct.hs
+++ b/ron-test/LwwStruct.hs
@@ -43,9 +43,9 @@ replica = applicationSpecific 0xd83d30067100000
 ex1expect :: ByteStringL
 ex1expect = [i|
     *lww    #B/00009ISodW+r3pl1c4   @`                  !
-                                                :int1   =275
+                                                :int1   275
                                                 :opt5   >none
-                                                :opt6   >some =74
+                                                :opt6   >some 74
                                                 :set4   >(1KqirW
                                                 :str2   >(6FAycW
                                                 :str3   '190'
@@ -62,7 +62,7 @@ ex1expect = [i|
 ex4expect :: ByteStringL
 ex4expect = [i|
     *lww    #B/00009ISodW+r3pl1c4   @`(c1l2MW               !
-                                    @(D81V2W    :int1       =166
+                                    @(D81V2W    :int1       166
                                     @`          :opt5       >none
                                     @(c1l2MW    :opt6       >none
                                     @`          :set4       >(1KqirW
@@ -70,7 +70,7 @@ ex4expect = [i|
                                     @(PEddUW    :str3       '206'
 
             #(YD2ZdW                @`          :0          !
-                                                :int1       =135
+                                                :int1       135
                                                 :opt5       >none
                                                 :opt6       >none
                                                 :set4       >(T6VGUW

--- a/ron-test/Main.hs
+++ b/ron-test/Main.hs
@@ -388,7 +388,7 @@ prop_ORSet = let
     state0expect = [["*set", "#B/00000omion+000000005j", "@`", "!"], ["."]]
     state1expect =
         [ ["*set", "#B/00000omion+000000005j", "@`(2xPmJ2", "!"]
-        , ["@", "=370"]
+        , ["@", "370"]
         , ["."]
         ]
     state2expect =

--- a/ron-test/ron-test.cabal
+++ b/ron-test/ron-test.cabal
@@ -32,6 +32,7 @@ test-suite common
         bytestring,
         containers,
         directory,
+        directory-tree,
         extra,
         filepath,
         hedgehog,

--- a/ron/lib/Attoparsec/Extra.hs
+++ b/ron/lib/Attoparsec/Extra.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Attoparsec.Extra
@@ -8,6 +9,7 @@ module Attoparsec.Extra
     , label
     , parseOnlyL
     , takeL
+    , definiteDouble
     , withInputSize
     , (??)
     , (<+>)
@@ -15,11 +17,12 @@ module Attoparsec.Extra
 
 import           RON.Prelude
 
-import           Data.Attoparsec.ByteString.Char8 (anyChar)
+import           Data.Attoparsec.ByteString.Char8 (anyChar, decimal, isDigit, isDigit_w8, signed)
 import qualified Data.Attoparsec.Internal.Types as Internal
 import           Data.Attoparsec.Lazy as Attoparsec
 import qualified Data.ByteString as BS
 import           Data.ByteString.Lazy (fromStrict, toStrict)
+import qualified Data.Scientific as Sci
 
 import           RON.Util (ByteStringL)
 
@@ -85,6 +88,46 @@ char c = do
         pure c
     else
         fail $ "Expected " ++ show c ++ ", got " ++ show c'
+
+-- Note: Derived from 'scientifically' from Data.Attoparsec.ByteString.Char8.
+-- A strict pair
+data SP = SP !Integer {-# UNPACK #-}!Int
+
+-- | Parses a definite double, i.e. it is not an integer. For this, the double has either a '.', and 'e'/'E' part or both.
+{-# INLINE definiteDouble #-}
+definiteDouble :: Parser Double
+definiteDouble = do
+    let minus = 45 -- ord '-'
+        plus  = 43 -- ord '+'
+    sign <- peekWord8'
+    let !positive = sign /= minus
+    when (sign == plus || sign == minus) $
+        void anyWord8
+
+    n <- decimal
+
+    let f fracDigits = SP (BS.foldl' step n fracDigits)
+                          (negate $ BS.length fracDigits)
+        step a w = a * 10 + fromIntegral (w - 48)
+
+    dotty <- peekWord8
+    -- '.' -> ascii 46
+    let hasDot = case dotty of
+                     Just 46 -> True
+                     _       -> False
+    SP c e <- if hasDot
+                 then anyWord8 *> (f <$> Attoparsec.takeWhile isDigit_w8)
+                 else pure (SP n 0)
+
+    let !signedCoeff | positive  =  c
+                     | otherwise = -c
+
+    let littleE = 101
+        bigE    = 69
+    (satisfy (\ex -> ex == littleE || ex == bigE) *>
+        fmap (Sci.toRealFloat . Sci.scientific signedCoeff . (e +)) (signed decimal)) <|>
+        (if hasDot then pure (Sci.toRealFloat $ Sci.scientific signedCoeff    e)
+                   else fail "Parsing double is ambiguous")
 
 (<+>) :: Parser a -> Parser a -> Parser a
 (<+>) p1 p2 = Internal.Parser $ \t pos more lose suc -> let

--- a/ron/ron.cabal
+++ b/ron/ron.cabal
@@ -37,6 +37,7 @@ library
         containers,
         hashable,
         mtl,
+        scientific,
         template-haskell,
         text,
         time,


### PR DESCRIPTION
What is missing, is serializing unambiguous UUIDs without prefix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ff-notes/ron/86)
<!-- Reviewable:end -->
